### PR TITLE
Remove the toolbar and lodash deps and bump the version

### DIFF
--- a/root/bower.json
+++ b/root/bower.json
@@ -7,10 +7,7 @@
   "copyright": "{%= author_name %}",
   "main": "{%= name %}.js",
   "dependencies": {
-    "scribe": "~1.2.2",
-    "scribe-plugin-toolbar": "~0.1.4",
-    "scribe-common": "~0.0.11",
-    "lodash-amd": "~2.4.1"
+    "scribe": "~1.4.0"
   },
   "devDependencies": {},
   "ignore": [


### PR DESCRIPTION
This removes the dependencies as we suggested and also makes sure new plugins are always using the latest scribe version.
